### PR TITLE
add db3 db_sql example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,9 @@ ac-primitives = { path = "primitives", default-features = false }
 env_logger = "0.9.0"
 node-template-runtime = { git = "https://github.com/dbpunk-labs/substrate.git", branch = "polkadot-v0.9.27" }
 node-runtime = { git = "https://github.com/dbpunk-labs/substrate.git", branch = "polkadot-v0.9.27" }
+db3-runtime = { git = "https://github.com/dbpunk-labs/db3.git", branch = "fix/db3-runtime-compile" }
 sp-keyring = { version = "6.0.0", git = "https://github.com/dbpunk-labs/substrate.git", branch = "polkadot-v0.9.27" }
+pallet-sql-db = { git = "https://github.com/dbpunk-labs/db3.git", branch = "fix/db3-runtime-compile" }
 clap = { version = "2.33", features = ["yaml"] }
 wabt = "0.10.0"
 

--- a/examples/example_db3_balance_transfer.rs
+++ b/examples/example_db3_balance_transfer.rs
@@ -18,7 +18,8 @@
 use clap::{load_yaml, App};
 
 use ac_primitives::AssetTipExtrinsicParamsBuilder;
-use node_runtime::{BalancesCall, Header, Call};
+use node_runtime::{Header};
+use db3_runtime::{BalancesCall, Call};
 use sp_keyring::AccountKeyring;
 use sp_runtime::generic::Era;
 use sp_runtime::MultiAddress;
@@ -56,12 +57,14 @@ fn main() {
 
     let updated_api = api.set_extrinsic_params_builder(tx_params);
     let nonce = updated_api.get_nonce().unwrap();
+    let bob_address = db3_runtime::Address::Id(db3_runtime::AccountId::new(AccountKeyring::Bob.to_account_id().into()));
+
     // compose the extrinsic with all the element
     #[allow(clippy::redundant_clone)]
     let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
         updated_api.clone().signer.unwrap(),
         Call::Balances(BalancesCall::transfer {
-            dest: MultiAddress::Id(to.clone()),
+            dest: bob_address.clone(),
             value: 42
         }),
         updated_api.extrinsic_params(nonce)

--- a/examples/example_db3_db_sql.rs
+++ b/examples/example_db3_db_sql.rs
@@ -1,0 +1,219 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+//! This examples shows how to use the compose_extrinsic_offline macro which generates an extrinsic
+//! without asking the node for nonce and does not need to know the metadata
+use std::sync::mpsc::{channel, Receiver};
+use std::str;
+use clap::{load_yaml, App};
+use codec::Decode;
+use node_template_runtime::Event;
+use ac_primitives::{AssetTipExtrinsicParamsBuilder, BaseExtrinsicParams};
+use db3_runtime::{Call};
+use sp_core::H256 as Hash;
+use substrate_api_client::utils::FromHexString;
+use node_runtime::{Header, Address};
+use sp_keyring::AccountKeyring;
+use sp_runtime::generic::Era;
+use substrate_api_client::rpc::WsRpcClient;
+use substrate_api_client::{compose_extrinsic_offline, Api, AssetTipExtrinsicParams, UncheckedExtrinsicV4, XtStatus, AssetTip, MultiAddress};
+
+
+fn main() {
+    env_logger::init();
+    let url = get_node_url_from_cli();
+
+    // initialize api and set the signer (sender) that is used to sign the extrinsics
+    let from = AccountKeyring::Alice.pair();
+    let client = WsRpcClient::new(&url);
+
+    let api = Api::<_, _, AssetTipExtrinsicParams>::new(client)
+        .map(|api| api.set_signer(from))
+        .unwrap();
+    // let meta = api.get_metadata();
+    // println!("Metadata:\n {:?}", meta);
+
+    // Information for Era for mortal transactions
+    println!("[+] Subscribe to events ... ");
+    let (events_in, events_out) = channel();
+    api.subscribe_events(events_in).unwrap();
+
+    let tx_param = generate_tx_param(&api);
+    let api = api.set_extrinsic_params_builder(tx_param);
+    println!(
+        "[+] Alice's Account Nonce is {}\n",
+        api.get_nonce().unwrap()
+    );
+
+    println!("[+] create ns >>>>>>>>");
+    // create_ns("test_ns", "1234");
+    #[allow(clippy::redundant_clone)]
+        let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
+        api.clone().signer.unwrap(),
+        Call::SQLDB(pallet_sql_db::Call::create_ns {
+            ns: "test_ns".as_bytes().to_vec(),
+            req_id: "1234".as_bytes().to_vec()
+        }),
+        api.extrinsic_params(api.get_nonce().unwrap())
+    );
+    log::debug!("[+] Composed Extrinsic:\n {:?}\n", xt);
+    // send and watch extrinsic until in block
+    let blockh = api
+        .send_extrinsic(xt.hex_encode(), XtStatus::InBlock)
+        .unwrap();
+    println!("[+] Transaction got included in block {:?}", blockh);
+
+    println!("[+] GeneralResultEvent:\n {}", receive_sqldb_event(&events_out));
+
+    let tx_param = generate_tx_param(&api);
+    let api = api.set_extrinsic_params_builder(tx_param);
+    println!(
+        "[+] Alice's Account Nonce is {}\n",
+        api.get_nonce().unwrap()
+    );
+    println!("[+] runSqlByOwner: create table >>>>>>>>");
+    #[allow(clippy::redundant_clone)]
+        let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
+        api.clone().signer.unwrap(),
+        Call::SQLDB(pallet_sql_db::Call::run_sql_by_owner {
+            data: "create table location(id INT NOT NULL PRIMARY KEY, coordinates VARCHAR(50));".as_bytes().to_vec(),
+            req_id: "1234".as_bytes().to_vec(),
+            ns: "test_ns".as_bytes().to_vec()
+        }),
+        api.extrinsic_params(api.get_nonce().unwrap())
+    );
+    log::debug!("[+] Composed Extrinsic:\n {:?}\n", xt);
+    // send and watch extrinsic until in block
+    let blockh = api
+        .send_extrinsic(xt.hex_encode(), XtStatus::InBlock)
+        .unwrap();
+    println!("[+] Transaction got included in block {:?}", blockh);
+
+    println!("[+] GeneralResultEvent:\n {}", receive_sqldb_event(&events_out));
+
+    let tx_param = generate_tx_param(&api);
+    let api = api.set_extrinsic_params_builder(tx_param);
+    println!(
+        "[+] Alice's Account Nonce is {}\n",
+        api.get_nonce().unwrap()
+    );
+    println!("[+] runSqlByOwner: insert table >>>>>>>>");
+    #[allow(clippy::redundant_clone)]
+        let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
+        api.clone().signer.unwrap(),
+        Call::SQLDB(pallet_sql_db::Call::run_sql_by_owner {
+            data: "insert into location values
+(1, '37.772,-122.214'),
+(2, '21.291,-157.821'),
+(3, '-18.142,178.431'),
+(4, '-27.467,153.027');".as_bytes().to_vec(),
+            req_id: "1234".as_bytes().to_vec(),
+            ns: "test_ns".as_bytes().to_vec()
+        }),
+        api.extrinsic_params(api.get_nonce().unwrap())
+    );
+    log::debug!("[+] Composed Extrinsic:\n {:?}\n", xt);
+    // send and watch extrinsic until in block
+    let blockh = api
+        .send_extrinsic(xt.hex_encode(), XtStatus::InBlock)
+        .unwrap();
+    println!("[+] Transaction got included in block {:?}", blockh);
+
+    println!("[+] GeneralResultEvent:\n {}", receive_sqldb_event(&events_out));
+
+    let tx_param = generate_tx_param(&api);
+    let api = api.set_extrinsic_params_builder(tx_param);
+    println!(
+        "[+] Alice's Account Nonce is {}\n",
+        api.get_nonce().unwrap()
+    );
+    println!("[+] runSqlByOwner: select * from table >>>>>>>>");
+    #[allow(clippy::redundant_clone)]
+        let xt: UncheckedExtrinsicV4<_, _> = compose_extrinsic_offline!(
+        api.clone().signer.unwrap(),
+        Call::SQLDB(pallet_sql_db::Call::run_sql_by_owner {
+            data: "select * from location;".as_bytes().to_vec(),
+            req_id: "1234".as_bytes().to_vec(),
+            ns: "test_ns".as_bytes().to_vec()
+        }),
+        api.extrinsic_params(api.get_nonce().unwrap())
+    );
+    log::debug!("[+] Composed Extrinsic:\n {:?}\n", xt);
+    // send and watch extrinsic until in block
+    let blockh = api
+        .send_extrinsic(xt.hex_encode(), XtStatus::InBlock)
+        .unwrap();
+    println!("[+] Transaction got included in block {:?}", blockh);
+
+    println!("[+] GeneralResultEvent:\n {}", receive_sqldb_event(&events_out));
+}
+
+/***
+Try to receive one GeneralResultEvent
+ */
+fn receive_sqldb_event(events_out: &Receiver<String>) -> String {
+    for _ in 0..5 {
+        let event_str = events_out.recv().unwrap();
+        let _unhex = Vec::from_hex(event_str).unwrap();
+        let mut _er_enc = _unhex.as_slice();
+        let _events = Vec::<system::EventRecord<db3_runtime::Event, Hash>>::decode(&mut _er_enc);
+        match _events {
+            Ok(evts) => {
+                for evr in &evts {
+                    log::debug!("decoded: {:?} {:?}", evr.phase, evr.event);
+                    match &evr.event {
+                        db3_runtime::Event::SQLDB(be) => {
+                            log::debug!(">>>>>>>>>> db3 SQLDB event: {:?}", be);
+                            match &be {
+                                pallet_sql_db::Event::GeneralResultEvent(event_data) => {
+                                    let json_str = match str::from_utf8(event_data) {
+                                        Ok(v) => v,
+                                        Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+                                    };
+                                    return String::from(json_str);
+                                }
+                                _ => {
+                                    log::debug!("ignoring unsupported SQLDB event");
+                                }
+                            }
+                        }
+                        _ => log::info!("ignoring unsupported module event: {:?}", evr.event),
+                    }
+                }
+            }
+            Err(_) => log::error!("couldn't decode event record list"),
+        }
+    }
+    String::from("")
+}
+
+pub fn get_node_url_from_cli() -> String {
+    let yml = load_yaml!("cli.yml");
+    let matches = App::from_yaml(yml).get_matches();
+
+    let node_ip = matches.value_of("node-server").unwrap_or("ws://127.0.0.1");
+    let node_port = matches.value_of("node-port").unwrap_or("9944");
+    let url = format!("{}:{}", node_ip, node_port);
+    println!("Interacting with node on {}\n", url);
+    url
+}
+
+fn generate_tx_param<P>(api: &Api<P, WsRpcClient, AssetTipExtrinsicParams>) -> AssetTipExtrinsicParamsBuilder {
+    let head = api.get_finalized_head().unwrap().unwrap();
+    let h: Header = api.get_header(Some(head)).unwrap().unwrap();
+    let period = 5;
+    AssetTipExtrinsicParamsBuilder::new()
+        .era(Era::mortal(period, h.number.into()), head)
+        .tip(AssetTip::new(0))
+}


### PR DESCRIPTION
### What changes
Add db3:DBSQL examples

- [x] create ns
- [x] run sql by owner
- [x] add delegate
- [x] runsql by delegate

Related Issue https://github.com/dbpunk-labs/db3/issues/86


### How to run

1. start db3
```
./target/release/db3 --dev
```

2. run example
```
git clone https://github.com/dbpunk-labs/substrate-api-client.git
cd substrate-api-client
cargo run --example example_db3_db_sql
```

Expected result
```
Interacting with node on ws://127.0.0.1:9944

[+] Subscribe to events ...
[+] Account Nonce is 0

[+] req_id: 1234, create ns >>>>>>>>
[+] Transaction got included in block Some(0xb71af839945bf0b36410aabde95f632354732cd382da4e624901432e10852286)
[+] GeneralResultEvent:
 {"status":0,"msg":"ok","req_id":"1234"}
[+] Account Nonce is 1

[+] req_id: 1235, runSqlByOwner: create table >>>>>>>>
[+] Transaction got included in block Some(0x7464e96c8b8381546c3032aed93ea864651960b60bda8d4383cf72c3f5f8dadd)
[+] GeneralResultEvent:
 {"status":0, "msg":"ok","req_id":"1235"}
[+] Account Nonce is 3

[+] req_id: 1236, runSqlByOwner: insert table >>>>>>>>
[+] Transaction got included in block Some(0x2bf26835bce4f8137c034b3efaf9ddcee29ffeed50dec51c160cc69b9b8e2122)
[+] GeneralResultEvent:
 {"status":0, "msg":"ok","req_id":"1236"}
[+] Account Nonce is 5

[+] req_id: 1237, runSqlByOwner: select * from table >>>>>>>>
[+] Transaction got included in block Some(0x6f4548ebc7287472581ec106305e10e6a46b8ee1bdf31c862b6df5c2884c15c9)
[+] GeneralResultEvent:
 {"status":0, "msg":"ok", "schema":{"fields":[{"name":"id","nullable":true,"type":{"name":"int","bitWidth":32,"isSigned":true},"children":[]},{"name":"coordinates","nullable":true,"type":{"name":"utf8"},"children":[]}],"metadata":{}}, "data":[{"id":1,"coordinates":"37.772,-122.214"},{"id":2,"coordinates":"21.291,-157.821"}], "req_id":"1237"}
[+] Account Nonce is 7

[+] req_id: 1238, add delegate to MultiAddress::Id(8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48 (5FHneW46...)) for test_ns >>>>>>>>
[+] Transaction got included in block Some(0x7ca99fe50b8b55e11b218fa5c01f090cba56d0f22ee052dca0bcd9c39b76ac11)
[+] GeneralResultEvent:
 {"status":0,"msg":"ok","req_id":"1238"}
Interacting with node on ws://127.0.0.1:9944

[+] Subscribe to events ...
[+] Delegate Account Nonce is 0

[+] req_id: 3235, runSqlByDelegate: insert table >>>>>>>>
[+] Transaction got included in block Some(0x7c2f9ba30b8913b1703adae156c66672e22050d4c6d73047997ae7011913f007)
[+] GeneralResultEvent:
 {"status":0, "msg":"ok","req_id":"3235"}
[+] Delegate Account Nonce is 1

[+] req_id: 3236, runSqlByDelegate: select * from table >>>>>>>>
[+] Transaction got included in block Some(0xf9b655c26509b1f530b158dd16a0bf14771e8b3458f8d0fbb5910580745edd38)
[+] GeneralResultEvent:
 {"status":0, "msg":"ok", "schema":{"fields":[{"name":"id","nullable":true,"type":{"name":"int","bitWidth":32,"isSigned":true},"children":[]},{"name":"coordinates","nullable":true,"type":{"name":"utf8"},"children":[]}],"metadata":{}}, "data":[{"id":1,"coordinates":"37.772,-122.214"},{"id":2,"coordinates":"21.291,-157.821"},{"id":3,"coordinates":"-18.142,178.431"},{"id":4,"coordinates":"-27.467,153.027"}], "req_id":"3236"}
```